### PR TITLE
Fix badly formatted link to code samples folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In relation to output of the games from Health Hack we would like to implement a
 
 - We will be making available 3 x Fizzyo Acepella Engineering devices to hacker for testing of game content
 
-- We have provided a Unity Sample Game which shows the input methods see [Fizzyo-Unity-Example] (https://github.com/ichealthhack/fizzyo-challenge/tree/master/Fizzyo-Unity-Example) Folder this contains pre calibration information, a sample game and test harness + test data
+- We have provided a Unity Sample Game which shows the input methods - see [Fizzyo-Unity-Example](https://github.com/ichealthhack/fizzyo-challenge/tree/master/Fizzyo-Unity-Example) Folder which contains pre calibration information, a sample game and test harness + test data
 
 - We have provided a Unity Test Harness and sample data. The data data set of captured results from the devices are for games testing. This includes an example that allows you to load and playback breath data saved from a fizzyo device.
 


### PR DESCRIPTION
I assume there was a newline between the link text and target.